### PR TITLE
draft, inmaputil: Modifying inmap.go to route certain outputs to Gobra

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -70,20 +70,36 @@
 [[projects]]
   branch = "master"
   name = "github.com/ctessum/atmos"
-  packages = ["acm2","advect","emep","evalstats","plumerise","seinfeld","wesely1989"]
+  packages = [
+    "acm2",
+    "advect",
+    "emep",
+    "evalstats",
+    "plumerise",
+    "seinfeld",
+    "wesely1989"
+  ]
   revision = "cba69f7ca647e4802a2fc348281d6ab269806a7a"
 
 [[projects]]
   branch = "master"
   name = "github.com/ctessum/geom"
-  packages = [".","carto","encoding/geojson","encoding/shp","index/rtree","op","proj"]
+  packages = [
+    ".",
+    "carto",
+    "encoding/geojson",
+    "encoding/shp",
+    "index/rtree",
+    "op",
+    "proj"
+  ]
   revision = "1cd0f1efc691950863e98ac8da882f497d5ce287"
 
 [[projects]]
   branch = "master"
   name = "github.com/ctessum/gobra"
   packages = ["."]
-  revision = "c4487115d72c87acf0eb24c90717cc07d615b836"
+  revision = "b2d4be2744ad48be2c2960c165442747eabaab42"
 
 [[projects]]
   branch = "master"
@@ -100,13 +116,23 @@
 [[projects]]
   branch = "master"
   name = "github.com/ctessum/unit"
-  packages = [".","badunit"]
+  packages = [
+    ".",
+    "badunit"
+  ]
   revision = "755774ac2fcbe68f090798b4cdc47c5cd056b1f5"
 
 [[projects]]
   branch = "master"
   name = "github.com/dsnet/compress"
-  packages = [".","bzip2","bzip2/internal/sais","internal","internal/errors","internal/prefix"]
+  packages = [
+    ".",
+    "bzip2",
+    "bzip2/internal/sais",
+    "internal",
+    "internal/errors",
+    "internal/prefix"
+  ]
   revision = "cc9eb1d7ad760af14e8f918698f745e80377af4f"
 
 [[projects]]
@@ -118,7 +144,11 @@
 [[projects]]
   branch = "master"
   name = "github.com/golang/freetype"
-  packages = [".","raster","truetype"]
+  packages = [
+    ".",
+    "raster",
+    "truetype"
+  ]
   revision = "e2365dfdc4a05e4b8299a783240d4a7d5a65d4e4"
 
 [[projects]]
@@ -142,7 +172,18 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/hcl"
-  packages = [".","hcl/ast","hcl/parser","hcl/printer","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  packages = [
+    ".",
+    "hcl/ast",
+    "hcl/parser",
+    "hcl/printer",
+    "hcl/scanner",
+    "hcl/strconv",
+    "hcl/token",
+    "json/parser",
+    "json/scanner",
+    "json/token"
+  ]
   revision = "23c074d0eceb2b8a5bfdbb271ab780cde70f05a8"
 
 [[projects]]
@@ -166,7 +207,11 @@
 [[projects]]
   branch = "master"
   name = "github.com/llgcode/draw2d"
-  packages = [".","draw2dbase","draw2dimg"]
+  packages = [
+    ".",
+    "draw2dbase",
+    "draw2dimg"
+  ]
   revision = "dcbfbe505d35de8166ccfc47ff9e4bb020473e18"
 
 [[projects]]
@@ -213,7 +258,10 @@
 
 [[projects]]
   name = "github.com/spf13/afero"
-  packages = [".","mem"]
+  packages = [
+    ".",
+    "mem"
+  ]
   revision = "8d919cbe7e2627e417f3e45c3c0e489a5b7e2536"
   version = "v1.0.0"
 
@@ -226,7 +274,10 @@
 [[projects]]
   branch = "master"
   name = "github.com/spf13/cobra"
-  packages = [".","doc"]
+  packages = [
+    ".",
+    "doc"
+  ]
   revision = "b95ab734e27d33e0d8fbabf71ca990568d4e2020"
 
 [[projects]]
@@ -249,20 +300,35 @@
 
 [[projects]]
   name = "github.com/ulikunitz/xz"
-  packages = [".","internal/hash","internal/xlog","lzma"]
+  packages = [
+    ".",
+    "internal/hash",
+    "internal/xlog",
+    "lzma"
+  ]
   revision = "0c6b41e72360850ca4f98dc341fd999726ea007f"
   version = "v0.5.4"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/image"
-  packages = ["draw","font","math/f64","math/fixed","tiff","tiff/lzw"]
+  packages = [
+    "draw",
+    "font",
+    "math/f64",
+    "math/fixed",
+    "tiff",
+    "tiff/lzw"
+  ]
   revision = "f7e31b4ea2e3413ab91b4e7d2dc83e5f8d19a44c"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context"]
+  packages = [
+    "context",
+    "websocket"
+  ]
   revision = "cd69bc3fc700721b709c3a59e16e24c67b58f6ff"
 
 [[projects]]
@@ -274,19 +340,51 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
+  packages = [
+    "internal/gen",
+    "internal/triegen",
+    "internal/ucd",
+    "transform",
+    "unicode/cldr",
+    "unicode/norm"
+  ]
   revision = "75cc3cad82b5f47d3fb229ddda8c5167da14f294"
 
 [[projects]]
   branch = "master"
   name = "gonum.org/v1/gonum"
-  packages = ["blas","blas/blas64","blas/gonum","floats","internal/asm/c128","internal/asm/f32","internal/asm/f64","internal/math32","lapack","lapack/gonum","lapack/lapack64","mat"]
+  packages = [
+    "blas",
+    "blas/blas64",
+    "blas/gonum",
+    "floats",
+    "internal/asm/c128",
+    "internal/asm/f32",
+    "internal/asm/f64",
+    "internal/math32",
+    "lapack",
+    "lapack/gonum",
+    "lapack/lapack64",
+    "mat"
+  ]
   revision = "ce73cefcda434183888c40895ea2fa306203906a"
 
 [[projects]]
   branch = "master"
   name = "gonum.org/v1/plot"
-  packages = [".","palette","plotter","tools/bezier","vg","vg/draw","vg/fonts","vg/vgeps","vg/vgimg","vg/vgpdf","vg/vgsvg"]
+  packages = [
+    ".",
+    "palette",
+    "plotter",
+    "tools/bezier",
+    "vg",
+    "vg/draw",
+    "vg/fonts",
+    "vg/vgeps",
+    "vg/vgimg",
+    "vg/vgpdf",
+    "vg/vgsvg"
+  ]
   revision = "50336e281717e5f1685e3c611828dfb42c82cf66"
 
 [[projects]]

--- a/eval/animation_test.go
+++ b/eval/animation_test.go
@@ -184,7 +184,7 @@ func TestAnimation_logo(t *testing.T) {
 	// framePeriod is the interval in seconds between snapshots
 	const framePeriod = 3600.0 * 3
 
-	if err := inmaputil.Run("animation_logo/logoOut.log", "animation_logo/logoOut.shp", false,
+	if err := inmaputil.Run(nil, "animation_logo/logoOut.log", "animation_logo/logoOut.shp", false,
 		map[string]string{"TotalPM25": "TotalPM25"}, inmaputil.Cfg.GetString("EmissionUnits"),
 		[]string{"animation_logo/logo.shp"},
 		cfg, inmaputil.Cfg.GetString("InMAPData"), inmaputil.Cfg.GetString("VariableGridData"), inmaputil.Cfg.GetInt("NumIterations"),
@@ -237,7 +237,7 @@ func TestAnimation_nei(t *testing.T) {
 	// framePeriod is the interval in seconds between snapshots
 	const framePeriod = 3600.0
 
-	if err := inmaputil.Run("animation_nei/results.log", "animation_nei/results.shp", false,
+	if err := inmaputil.Run(nil, "animation_nei/results.log", "animation_nei/results.shp", false,
 		inmaputil.GetStringMapString("OutputVariables", inmaputil.Cfg), inmaputil.Cfg.GetString("EmissionUnits"),
 		inmaputil.Cfg.GetStringSlice("EmissionsShapefiles"),
 		cfg, inmaputil.Cfg.GetString("InMAPData"), inmaputil.Cfg.GetString("VariableGridData"), inmaputil.Cfg.GetInt("NumIterations"),

--- a/inmaputil/cmd.go
+++ b/inmaputil/cmd.go
@@ -677,6 +677,7 @@ concentrations with no temporal variability.`,
 		}
 
 		return Run(
+			cmd,
 			checkLogFile(Cfg.GetString("LogFile"), outputFile),
 			outputFile,
 			Cfg.GetBool("OutputAllLayers"),

--- a/inmaputil/inmap.go
+++ b/inmaputil/inmap.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/spatialmodel/inmap"
 	"github.com/spatialmodel/inmap/science/chem/simplechem"
+	"github.com/spf13/cobra"
 )
 
 func getCTMData(inmapData string, VarGrid *inmap.VarGridConfig) (*inmap.CTMData, error) {
@@ -66,6 +67,9 @@ var DefaultScienceFuncs = []inmap.CellManipulator{
 // Run runs the model. dynamic and createGrid specify whether the variable
 // resolution grid should be created dynamically and whether the static
 // grid should be created or read from a file, respectively.
+//
+// CobraCommand is the cobra.Command instance where Run is called from.
+// It is needed to print certain outputs to the web interface.
 //
 // LogFile is the path to the desired logfile location. It can include
 // environment variables. If LogFile is left blank, the logfile will be saved in
@@ -110,7 +114,7 @@ var DefaultScienceFuncs = []inmap.CellManipulator{
 //
 // notMeters should be set to true if the units of the grid are not meters
 // (e.g., if the grid is in degrees latitude/longitude.)
-func Run(LogFile string, OutputFile string, OutputAllLayers bool, OutputVariables map[string]string,
+func Run(CobraCommand *cobra.Command, LogFile string, OutputFile string, OutputAllLayers bool, OutputVariables map[string]string,
 	EmissionUnits string, EmissionsShapefiles []string, VarGrid *inmap.VarGridConfig, InMAPData, VariableGridData string,
 	NumIterations int,
 	dynamic, createGrid bool, scienceFuncs []inmap.CellManipulator, addInit, addRun, addCleanup []inmap.DomainManipulator,
@@ -124,7 +128,7 @@ func Run(LogFile string, OutputFile string, OutputAllLayers bool, OutputVariable
 		return fmt.Errorf("inmap: problem creating log file: %v", err)
 	}
 	defer logfile.Close()
-	mw := io.MultiWriter(os.Stdout, logfile)
+	mw := io.MultiWriter(CobraCommand.OutOrStdout(), logfile)
 	log.SetOutput(mw)
 	cConverge := make(chan inmap.ConvergenceStatus)
 	cLog := make(chan *inmap.SimulationStatus)


### PR DESCRIPTION
Hi Chris,

This is the way I'd route messages from InMap to Gobra (web interface).

The browser isn't happy with it being bombarded with thousands of messages, so I couldn't add `CobraCommand.OutOrStdout()` to `mw` MultiWriter (in line 131 of inmaputil/inmap.go).

However, I routed some of the messages, and it was okay with that. 
Here's a screenshot showing the `percentage change since last convergence check` and the `adding grid cells...` but not the `iteration xxx walltime=[...]`.

Hope this makes sense. I figured you would know better about which messages you'd prefer to send to the browser as well, so this PR is merely a draft.

----
I am not exactly sure where to put the documentation for this because it's scattered everywhere, but here are different ways to print a message to the browser:
* Use `*cobra.Command` print methods when InMap is running with Gobra. E.g., Println, Printf, etc.
* Write to `*cobra.Command.OutOrStdout()` when InMap is running with Gobra ([this line](https://github.com/khoin/gobra/blob/master/gobra.go#L208) sets Cobra output to Gobra). E.g. `cmd.OutOrStdout().Write([]byte("Test"))`
* Write directly to `gobra.Server`. This struct implements `io.Writer` where `Write`ing to it will output on the browser. This struct gets pointed to by `OutOrStdout()` above when run with InMap/Cobra.

Let me know if anything is unclear.

![image](https://user-images.githubusercontent.com/4620399/38950223-aa06976e-42f9-11e8-8b81-b1bc43b6aab9.png)
