### PR TITLE
docs: Fix links between docs files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ You can also compile InMAP from its source code. The instructions here are speci
 3. Create an emissions scenario or use one of the evaluation emissions datasets available in the `evaldata_vX.X.X.zip` files on the [InMAP release page](https://github.com/spatialmodel/inmap/releases). Emissions files should be in [shapefile](http://en.wikipedia.org/wiki/Shapefile) format where the attribute columns correspond to the names of emitted pollutants. The acceptable pollutant names are
 `VOC`, `NOx`, `NH3`, `SOx`, and `PM2_5`. Emissions units can be specified in the configuration file (discussed below) and can be short tons per year,  kilograms per year, or micrograms per second. The model can handle multiple input emissions files, and emissions can be either elevated or ground level. Files with elevated emissions need to have attribute columns labeled "height", "diam", "temp", and "velocity" containing stack information in units of m, m, K, and m/s, respectively. Emissions will be allocated from the geometries in the shape file to the InMAP computational grid.
 
-1. Make a copy of the [configuration file template](eval/nei2005Config.toml) and edit it if desired, keeping in mind that you will either need to set the `evaldata` environment variable to the directory you downloaded the evaluation data to, or replace all instances of `${evaldata}` in the configuration file with the path to that directory. You must also ensure that the directory `OutputFile` is to go in exists. Refer to the documentation [here](inmap/doc/inmap.md) for information about other configuration options. The configuration file is a text file in [TOML](https://github.com/toml-lang/toml) format, and any changes made to the file will need to conform to that format or the model will not run correctly and will produce an error.
+1. Make a copy of the [configuration file template](eval/nei2005Config.toml) and edit it if desired, keeping in mind that you will either need to set the `evaldata` environment variable to the directory you downloaded the evaluation data to, or replace all instances of `${evaldata}` in the configuration file with the path to that directory. You must also ensure that the directory `OutputFile` is to go in exists. Refer to the documentation [here](docs/cmd/inmap.md) for information about other configuration options. The configuration file is a text file in [TOML](https://github.com/toml-lang/toml) format, and any changes made to the file will need to conform to that format or the model will not run correctly and will produce an error.
 
 2. Run the program:
 
 		inmapXXX run steady --config=/path/to/configfile.toml
 	where `inmapXXX` is replaced with the executable file that you [downloaded](https://github.com/spatialmodel/inmap/releases). For some systems you may need to type `./inmapXXX` instead. If you compiled the program from source, the command will just be `inmap` for Linux or Mac systems and `inmap.exe` for Windows systems.
 
-	The above command runs the model in the most typical mode. For alternative run modes and other command options refer [here](inmap/doc/inmap.md).
+	The above command runs the model in the most typical mode. For alternative run modes and other command options refer [here](docs/cmd/inmap.md).
 
 3. View the program output. The output files are in [shapefile](http://en.wikipedia.org/wiki/Shapefile) format which can be viewed in most GIS programs. One free GIS program is [QGIS](http://www.qgis.org/). By default, the InMAP only outputs ground-level, but this can be changed using the configuration file.
 
@@ -66,7 +66,7 @@ You can also compile InMAP from its source code. The instructions here are speci
 
 	Output variable expressions are, by default, evaluated within each grid cell. By surrounding an expression with braces ({...}), InMAP can instead perform summary calculations (evaluating the expression across all grid cells). InMAP has a built-in function `sum()` that can be used for such grid level calculations. For example, an expression for a variable `NPctWNoLat`, representing the percentage of the total US population that is Non-Latino White, would be `NPctWNoLat = "{sum(WhiteNoLat) / sum(TotalPop)}"`. Only the part of the expression inside of the braces is evaluated at the grid level. `NPctWNoLat` could then be used as a variable in expressions evaluated at the grid cell level, e.g, `WhNoLatDiff = "PctWhNoLat - NPctWNoLat"`, representing the difference between the percentage of the population of each grid cell that is white and the percentage of the total US population that is white.
 
-	There is a complete list of built-in variables [here](doc/OutputOptions.md). Some examples include:
+	There is a complete list of built-in variables [here](docs/output_options.md). Some examples include:
 	* Pollutant concentrations in units of μg m<sup>-3</sup>:
 	  * VOC (`VOC`)
 		* NO<sub>x</sub> (`NOx`)
@@ -88,7 +88,11 @@ You can also compile InMAP from its source code. The instructions here are speci
 
 ### Running the preprocessor
 
-InMAP includes a preprocessor to convert chemical transport model (CTM) output into InMAP meteorology and baseline chemistry input data. Unlike the main InMAP model, the preprocessor only needs to be run once for each spatiotemporal domain. Users that would like to use a different spatial or temporal domain than what is included with the InMAP download can obtain CTM output for that domain and run the preprocessor themselves. The WRF-Chem and GEOS-Chem CTMs are currently supported. Information on how to run the preprocessor is [here](inmap/doc/inmap_preproc.md), and information regarding preprocessor configuration is [here](https://godoc.org/github.com/spatialmodel/inmap/inmaputil#ConfigData.Preproc).
+InMAP includes a preprocessor to convert chemical transport model (CTM) output into InMAP meteorology and baseline chemistry input data.
+Unlike the main InMAP model, the preprocessor only needs to be run once for each spatiotemporal domain.
+Users that would like to use a different spatial or temporal domain than what is included with the InMAP download can obtain CTM output for that domain and run the preprocessor themselves.
+The WRF-Chem and GEOS-Chem CTMs are currently supported.
+Information on how to run the preprocessor is [here](docs/cmd/inmap_preproc.md), and information regarding preprocessor configuration is [here](https://godoc.org/github.com/spatialmodel/inmap/inmaputil#ConfigData.Preproc).
 
 ## API
 

--- a/docs/cmd/inmap.md
+++ b/docs/cmd/inmap.md
@@ -32,11 +32,10 @@ InMAP is a reduced-form air quality model for fine particulate matter (PM2.5).
 
 ### SEE ALSO
 
-* [inmap cloud](inmap_cloud)	 - Interact with a Kubernetes cluster.
-* [inmap grid](inmap_grid)	 - Create a variable resolution grid
-* [inmap preproc](inmap_preproc)	 - Preprocess CTM output
-* [inmap run](inmap_run)	 - Run the model.
-* [inmap sr](inmap_sr)	 - Interact with an SR matrix.
-* [inmap srpredict](inmap_srpredict)	 - Predict concentrations
-* [inmap version](inmap_version)	 - Print the version number
-
+* [inmap cloud](../inmap_cloud)	 - Interact with a Kubernetes cluster.
+* [inmap grid](../inmap_grid)	 - Create a variable resolution grid
+* [inmap preproc](../inmap_preproc)	 - Preprocess CTM output
+* [inmap run](../inmap_run)	 - Run the model.
+* [inmap sr](../inmap_sr)	 - Interact with an SR matrix.
+* [inmap srpredict](../inmap_srpredict)	 - Predict concentrations
+* [inmap version](../inmap_version)	 - Print the version number

--- a/docs/cmd/inmap_cloud.md
+++ b/docs/cmd/inmap_cloud.md
@@ -31,9 +31,8 @@ Interact with a Kubernetes cluster.
 
 ### SEE ALSO
 
-* [inmap](inmap)	 - A reduced-form air quality model.
-* [inmap cloud delete](inmap_cloud_delete)	 - Delete a cloud job.
-* [inmap cloud output](inmap_cloud_output)	 - Retrieve and save the output of a job on a Kubernetes cluster.
-* [inmap cloud start](inmap_cloud_start)	 - Start a job on a Kubernetes cluster.
-* [inmap cloud status](inmap_cloud_status)	 - Check the status of a job on a Kubernetes cluster.
-
+* [inmap](../inmap)	 - A reduced-form air quality model.
+* [inmap cloud delete](../inmap_cloud_delete)	 - Delete a cloud job.
+* [inmap cloud output](../inmap_cloud_output)	 - Retrieve and save the output of a job on a Kubernetes cluster.
+* [inmap cloud start](../inmap_cloud_start)	 - Start a job on a Kubernetes cluster.
+* [inmap cloud status](../inmap_cloud_status)	 - Check the status of a job on a Kubernetes cluster.

--- a/docs/cmd/inmap_cloud_delete.md
+++ b/docs/cmd/inmap_cloud_delete.md
@@ -35,5 +35,4 @@ inmap cloud delete [flags]
 
 ### SEE ALSO
 
-* [inmap cloud](inmap_cloud)	 - Interact with a Kubernetes cluster.
-
+* [inmap cloud](../inmap_cloud)	 - Interact with a Kubernetes cluster.

--- a/docs/cmd/inmap_cloud_output.md
+++ b/docs/cmd/inmap_cloud_output.md
@@ -35,5 +35,4 @@ inmap cloud output [flags]
 
 ### SEE ALSO
 
-* [inmap cloud](inmap_cloud)	 - Interact with a Kubernetes cluster.
-
+* [inmap cloud](../inmap_cloud)	 - Interact with a Kubernetes cluster.

--- a/docs/cmd/inmap_cloud_start.md
+++ b/docs/cmd/inmap_cloud_start.md
@@ -124,5 +124,4 @@ inmap cloud start [flags]
 
 ### SEE ALSO
 
-* [inmap cloud](inmap_cloud)	 - Interact with a Kubernetes cluster.
-
+* [inmap cloud](../inmap_cloud)	 - Interact with a Kubernetes cluster.

--- a/docs/cmd/inmap_cloud_status.md
+++ b/docs/cmd/inmap_cloud_status.md
@@ -35,5 +35,4 @@ inmap cloud status [flags]
 
 ### SEE ALSO
 
-* [inmap cloud](inmap_cloud)	 - Interact with a Kubernetes cluster.
-
+* [inmap cloud](../inmap_cloud)	 - Interact with a Kubernetes cluster.

--- a/docs/cmd/inmap_grid.md
+++ b/docs/cmd/inmap_grid.md
@@ -106,5 +106,4 @@ inmap grid [flags]
 
 ### SEE ALSO
 
-* [inmap](inmap)	 - A reduced-form air quality model.
-
+* [inmap](../inmap)	 - A reduced-form air quality model.

--- a/docs/cmd/inmap_preproc.md
+++ b/docs/cmd/inmap_preproc.md
@@ -99,5 +99,4 @@ inmap preproc [flags]
 
 ### SEE ALSO
 
-* [inmap](inmap)	 - A reduced-form air quality model.
-
+* [inmap](../inmap)	 - A reduced-form air quality model.

--- a/docs/cmd/inmap_run.md
+++ b/docs/cmd/inmap_run.md
@@ -133,6 +133,5 @@ run runs an InMAP simulation. Use the subcommands specified below to
 
 ### SEE ALSO
 
-* [inmap](inmap)	 - A reduced-form air quality model.
-* [inmap run steady](inmap_run_steady)	 - Run InMAP in steady-state mode.
-
+* [inmap](../inmap)	 - A reduced-form air quality model.
+* [inmap run steady](../inmap_run_steady)	 - Run InMAP in steady-state mode.

--- a/docs/cmd/inmap_run_steady.md
+++ b/docs/cmd/inmap_run_steady.md
@@ -1,4 +1,4 @@
----
+3---
 id: inmap_run_steady
 title: inmap run steady
 sidebar_label: inmap run steady
@@ -140,5 +140,4 @@ inmap run steady [flags]
 
 ### SEE ALSO
 
-* [inmap run](inmap_run)	 - Run the model.
-
+* [inmap run](../inmap_run)	 - Run the model.

--- a/docs/cmd/inmap_sr.md
+++ b/docs/cmd/inmap_sr.md
@@ -40,8 +40,7 @@ Interact with an SR matrix.
 
 ### SEE ALSO
 
-* [inmap](inmap)	 - A reduced-form air quality model.
-* [inmap sr clean](inmap_sr_clean)	 - clean cleans up temporary simulation output
-* [inmap sr save](inmap_sr_save)	 - Save simulation results to create an SR matrix
-* [inmap sr start](inmap_sr_start)	 - Start simulations to create an SR matrix
-
+* [inmap](../inmap)	 - A reduced-form air quality model.
+* [inmap sr clean](../inmap_sr_clean)	 - clean cleans up temporary simulation output
+* [inmap sr save](../inmap_sr_save)	 - Save simulation results to create an SR matrix
+* [inmap sr start](../inmap_sr_start)	 - Start simulations to create an SR matrix

--- a/docs/cmd/inmap_sr_clean.md
+++ b/docs/cmd/inmap_sr_clean.md
@@ -44,5 +44,4 @@ inmap sr clean [flags]
 
 ### SEE ALSO
 
-* [inmap sr](inmap_sr)	 - Interact with an SR matrix.
-
+* [inmap sr](../inmap_sr)	 - Interact with an SR matrix.

--- a/docs/cmd/inmap_sr_save.md
+++ b/docs/cmd/inmap_sr_save.md
@@ -47,5 +47,4 @@ inmap sr save [flags]
 
 ### SEE ALSO
 
-* [inmap sr](inmap_sr)	 - Interact with an SR matrix.
-
+* [inmap sr](../inmap_sr)	 - Interact with an SR matrix.

--- a/docs/cmd/inmap_sr_start.md
+++ b/docs/cmd/inmap_sr_start.md
@@ -132,5 +132,4 @@ inmap sr start [flags]
 
 ### SEE ALSO
 
-* [inmap sr](inmap_sr)	 - Interact with an SR matrix.
-
+* [inmap sr](../inmap_sr)	 - Interact with an SR matrix.

--- a/docs/cmd/inmap_srpredict.md
+++ b/docs/cmd/inmap_srpredict.md
@@ -60,5 +60,4 @@ inmap srpredict [flags]
 
 ### SEE ALSO
 
-* [inmap](inmap)	 - A reduced-form air quality model.
-
+* [inmap](../inmap)	 - A reduced-form air quality model.

--- a/docs/cmd/inmap_version.md
+++ b/docs/cmd/inmap_version.md
@@ -31,5 +31,4 @@ inmap version [flags]
 
 ### SEE ALSO
 
-* [inmap](inmap)	 - A reduced-form air quality model.
-
+* [inmap](../inmap)	 - A reduced-form air quality model.

--- a/docs/run_config.md
+++ b/docs/run_config.md
@@ -28,7 +28,7 @@ The exact command may vary depending on your system configuration, and you may n
 
 ### Subcommands
 
-The available ImMAP subcommands are listed in the [InMAP command documentation](cmd/inmap.md), which also includes descriptions of what each command does and the available configuration settings.
+The available InMAP subcommands are listed in the [InMAP command documentation](cmd/inmap.md), which also includes descriptions of what each command does and the available configuration settings.
 
 ## Configuration
 


### PR DESCRIPTION
This PR fixes links in the Github README.md and in the "see also" sections of the docs on the [inmap.run](https://inmap.run) site.
For example, on https://inmap.run/docs/cmd/inmap_grid/#see-also, the link points to https://inmap.run/docs/cmd/inmap_grid/inmap but should point to https://inmap.run/docs/cmd/inmap

I haven't generated new HTML from these edits, but I'd be happy to if you tell me how.


<!--
Checklist:

- API changes have been discussed
- code is goformated correctly (goimports)
- packages with generated code have had code generation run
- tests pass locally
- linked to relevant issues

Please make sure your commit message summary line and pull request
title match the Go convention; a one-line summary of the change,
prefixed by the primary affected package that should complete the
sentence, "This change modifies InMAP to _____."

Example pull request/commit title:
`inmaputil: Add documentation to cmd.go`
-->
